### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ else
     exit
 fi
 
-sudo apt-get install -y cmake-qt-gui git build-essential libusb-1.0-0-dev libudev-dev openjdk-7-jdk freeglut3-dev libglew-dev libsuitesparse-dev libeigen3-dev zlib1g-dev libjpeg-dev
+sudo apt-get install -y cmake-qt-gui git build-essential libusb-1.0-0-dev libudev-dev openjdk-8-jdk freeglut3-dev libglew-dev libsuitesparse-dev libeigen3-dev zlib1g-dev libjpeg-dev
 
 #Installing Pangolin
 git clone https://github.com/stevenlovegrove/Pangolin.git


### PR DESCRIPTION
The older OpenJDK 7 is not available in the Ubuntu 18.04.1 repositories.
The build script fails to download the dependencies, so I propose to change it to `openjdk-8-jdk`.